### PR TITLE
lu: Emit AppRunning event after launching all processes

### DIFF
--- a/app.go
+++ b/app.go
@@ -201,8 +201,6 @@ func (a *App) Launch(ctx context.Context) error {
 		return err
 	}
 
-	a.OnEvent(ctx, Event{Type: AppRunning})
-
 	// Create the app context now
 	appCtx, appCancel := context.WithCancel(ctx)
 	eg, appCtx := errgroup.WithContext(appCtx)
@@ -228,15 +226,16 @@ func (a *App) Launch(ctx context.Context) error {
 			ctx = pprof.WithLabels(ctx, pprof.Labels("lu_process", p.Name))
 		}
 
+		a.OnEvent(ctx, Event{Type: ProcessStart, Name: p.Name})
 		eg.Go(func() error {
 			pprof.SetGoroutineLabels(ctx)
 			defer close(doneCh)
-			a.OnEvent(ctx, Event{Type: ProcessStart, Name: p.Name})
 			defer a.OnEvent(ctx, Event{Type: ProcessEnd, Name: p.Name})
 			// NOTE: Any error returned by any of the processes will cause the entire App to terminate
 			return p.Run(ctx)
 		})
 	}
+	a.OnEvent(ctx, Event{Type: AppRunning})
 	return ctx.Err()
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -73,12 +73,14 @@ func TestLifecycle(t *testing.T) {
 		test.Event{Type: lu.AppStartup},
 		test.Event{Type: lu.PreHookStart, Name: "basic start hook"},
 		test.Event{Type: lu.PostHookStart, Name: "basic start hook"},
-		test.Event{Type: lu.AppRunning},
 		test.AnyOrder(
 			test.Event{Type: lu.ProcessStart, Name: "one"},
 			test.Event{Type: lu.ProcessStart, Name: "two"},
 			test.Event{Type: lu.ProcessStart, Name: "three"},
 			test.Event{Type: lu.ProcessStart, Name: "break loop"},
+		),
+		test.AnyOrder(
+			test.Event{Type: lu.AppRunning},
 			test.Event{Type: lu.ProcessEnd, Name: "break loop"},
 		),
 		test.Event{Type: lu.AppTerminating},

--- a/event.go
+++ b/event.go
@@ -13,7 +13,7 @@ const (
 	AppStartup               // First event, emitted right at the start
 	PreHookStart             // Emitted just before running each Hook.Start
 	PostHookStart            // Emitted just after completing a Hook.Start
-	AppRunning               // Emitted after running every startup Hook
+	AppRunning               // Emitted after starting every process
 	ProcessStart             // Emitted before starting to run a Process
 	ProcessEnd               // Emitted when a Process terminates
 	AppTerminating           // Emitted when the application starts termination

--- a/process/loop_break_test.go
+++ b/process/loop_break_test.go
@@ -44,12 +44,14 @@ func TestLifecycle(t *testing.T) {
 		test.Event{Type: lu.AppStartup},
 		test.Event{Type: lu.PreHookStart, Name: "basic start hook"},
 		test.Event{Type: lu.PostHookStart, Name: "basic start hook"},
-		test.Event{Type: lu.AppRunning},
 		test.AnyOrder(
 			test.Event{Type: lu.ProcessStart, Name: "noop"},
 			test.Event{Type: lu.ProcessStart, Name: "error"},
 			test.Event{Type: lu.ProcessStart, Name: "continue loop"},
 			test.Event{Type: lu.ProcessStart, Name: "break loop"},
+		),
+		test.AnyOrder(
+			test.Event{Type: lu.AppRunning},
 			test.Event{Type: lu.ProcessEnd, Name: "break loop"},
 		),
 	)


### PR DESCRIPTION
The aim of this PR is to only run the AppRunning event after launching all process goroutines. This better indicates the lifecycle state of the application.