### PR TITLE
app: Defer cleanup to ensure pid file removal

### DIFF
--- a/file.go
+++ b/file.go
@@ -35,7 +35,9 @@ func createPIDFile() error {
 
 func removePIDFile(ctx context.Context) {
 	err := os.Remove(fileName)
-	if err != nil {
+	if errors.Is(err, os.ErrNotExist) {
+		// NoReturnErr: File already gone, no worries
+	} else if err != nil {
 		// NoReturnErr: We'll terminate after this so just log
 		log.Error(ctx, errors.Wrap(err, "remove pid file", j.KV("file", fileName)))
 	}


### PR DESCRIPTION
If the process errors during start up or shutdown, then we still need to remove the pid file. This can also happen if we panic.

A deferred function from Run will make sure that we always call that cleanup.