### PR TITLE
ctx: Use Cause to return different errors

### DIFF
--- a/app.go
+++ b/app.go
@@ -98,8 +98,8 @@ func (a *App) startup(ctx context.Context) error {
 	defer pprof.SetGoroutineLabels(ctx)
 
 	for idx, h := range a.startupHooks {
-		if ctx.Err() != nil {
-			return ctx.Err()
+		if context.Cause(ctx) != nil {
+			return context.Cause(ctx)
 		}
 		a.OnEvent(ctx, Event{Type: PreHookStart, Name: h.Name})
 		hookCtx := ctx
@@ -114,14 +114,14 @@ func (a *App) startup(ctx context.Context) error {
 		}
 		a.OnEvent(ctx, Event{Type: PostHookStart, Name: h.Name})
 	}
-	return ctx.Err()
+	return context.Cause(ctx)
 }
 
 func (a *App) runShutdownHooks(ctx context.Context) error {
 	var errs []error
 	for idx, h := range a.shutdownHooks {
-		if ctx.Err() != nil {
-			return ctx.Err()
+		if context.Cause(ctx) != nil {
+			return context.Cause(ctx)
 		}
 		a.OnEvent(ctx, Event{Type: PreHookStop, Name: h.Name})
 		hookCtx := log.ContextWith(ctx, j.MKV{"hook_idx": idx, "hook_name": h.Name})
@@ -233,7 +233,7 @@ func (a *App) Launch(ctx context.Context) error {
 		})
 	}
 	a.OnEvent(ctx, Event{Type: AppRunning})
-	return ctx.Err()
+	return context.Cause(ctx)
 }
 
 // WaitForShutdown returns a channel that waits for the application to be cancelled.
@@ -331,7 +331,7 @@ func (a *App) cleanup(ctx context.Context) {
 // It will return an error if cancelled early.
 func Wait(ctx context.Context, cl clock.Clock, d time.Duration) error {
 	if d <= 0 {
-		return ctx.Err()
+		return context.Cause(ctx)
 	}
 	ti := cl.NewTimer(d)
 	defer ti.Stop()
@@ -357,7 +357,7 @@ func WaitFor[T any](ctx context.Context, ch <-chan T) (T, error) {
 		return v, nil
 	case <-ctx.Done():
 		var v T
-		return v, ctx.Err()
+		return v, context.Cause(ctx)
 	}
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -337,6 +337,18 @@ func TestWaitFor(t *testing.T) {
 			expErr: context.Canceled,
 		},
 		{
+			name: "time out",
+			ctx: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+				t.Cleanup(cancel)
+				return ctx
+			},
+			ch: func(t *testing.T) chan int {
+				return nil
+			},
+			expErr: context.DeadlineExceeded,
+		},
+		{
 			name: "success",
 			ctx: func(t *testing.T) context.Context {
 				return context.Background()

--- a/app_test.go
+++ b/app_test.go
@@ -37,7 +37,7 @@ func TestLifecycle(t *testing.T) {
 			Run: func(ctx context.Context) error {
 				log.Info(ctx, "one")
 				<-ctx.Done()
-				return ctx.Err()
+				return context.Cause(ctx)
 			},
 		},
 		lu.Process{
@@ -45,7 +45,7 @@ func TestLifecycle(t *testing.T) {
 			Run: func(ctx context.Context) error {
 				log.Info(ctx, "two")
 				<-ctx.Done()
-				return ctx.Err()
+				return context.Cause(ctx)
 			},
 		},
 		lu.Process{
@@ -53,7 +53,7 @@ func TestLifecycle(t *testing.T) {
 			Run: func(ctx context.Context) error {
 				log.Info(ctx, "three")
 				<-ctx.Done()
-				return ctx.Err()
+				return context.Cause(ctx)
 			},
 		},
 		process.ContextLoop(
@@ -103,7 +103,7 @@ func TestShutdownWithParentContext(t *testing.T) {
 	a.AddProcess(lu.Process{
 		Run: func(ctx context.Context) error {
 			<-ctx.Done()
-			return ctx.Err()
+			return context.Cause(ctx)
 		},
 	})
 
@@ -140,7 +140,7 @@ func TestProcessShutdown(t *testing.T) {
 				a.ShutdownTimeout = 100 * time.Millisecond
 				a.AddProcess(lu.Process{Shutdown: func(ctx context.Context) error {
 					<-ctx.Done()
-					return ctx.Err()
+					return context.Cause(ctx)
 				}})
 			},
 			expErr: context.DeadlineExceeded,

--- a/app_test.go
+++ b/app_test.go
@@ -322,7 +322,6 @@ func TestWaitFor(t *testing.T) {
 			ch: func(t *testing.T) chan int {
 				return nil
 			},
-			exp:    0,
 			expErr: io.ErrUnexpectedEOF,
 		},
 		{
@@ -335,7 +334,6 @@ func TestWaitFor(t *testing.T) {
 			ch: func(t *testing.T) chan int {
 				return nil
 			},
-			exp:    0,
 			expErr: context.Canceled,
 		},
 		{

--- a/process/loop.go
+++ b/process/loop.go
@@ -103,7 +103,7 @@ func wrapContextLoop(getCtx ContextFunc, f lu.ProcessFunc, opts options) lu.Proc
 				return err
 			}
 		}
-		return ctx.Err()
+		return context.Cause(ctx)
 	}
 }
 
@@ -143,7 +143,7 @@ func ContextRetry(
 				break
 			}
 		}
-		return ctx.Err()
+		return context.Cause(ctx)
 	}
 	return p
 }

--- a/process/noop.go
+++ b/process/noop.go
@@ -12,7 +12,7 @@ func NoOp() lu.Process {
 		Name: "noop",
 		Run: func(ctx context.Context) error {
 			<-ctx.Done()
-			return ctx.Err()
+			return context.Cause(ctx)
 		},
 	}
 }

--- a/process/reflex_test.go
+++ b/process/reflex_test.go
@@ -42,7 +42,7 @@ func (c *consumer) Stop() error {
 func Test_ReflexConsumer_afterLoop(t *testing.T) {
 	awaitFunc := func(role string) func(ctx context.Context) (context.Context, context.CancelFunc, error) {
 		return func(ctx context.Context) (context.Context, context.CancelFunc, error) {
-			return ctx, func() {}, ctx.Err()
+			return ctx, func() {}, context.Cause(ctx)
 		}
 	}
 	makeStream := func(ctx context.Context, after string, opts ...reflex.StreamOption) (reflex.StreamClient, error) {
@@ -63,7 +63,7 @@ func Test_ReflexConsumer_afterLoop(t *testing.T) {
 func Test_ReflexConsumer_breakLoop(t *testing.T) {
 	awaitFunc := func(role string) func(ctx context.Context) (context.Context, context.CancelFunc, error) {
 		return func(ctx context.Context) (context.Context, context.CancelFunc, error) {
-			return ctx, func() {}, ctx.Err()
+			return ctx, func() {}, context.Cause(ctx)
 		}
 	}
 	makeStream := func(ctx context.Context, after string, opts ...reflex.StreamOption) (reflex.StreamClient, error) {

--- a/process/schedule.go
+++ b/process/schedule.go
@@ -240,7 +240,7 @@ func processLoop(ctx context.Context, process processFunc, wait waitFunc) error 
 			return err
 		}
 	}
-	return ctx.Err()
+	return context.Cause(ctx)
 }
 
 // processOnce may panic if awaitRole is nil or if when calling it returns a nil role.ContextFunc, and

--- a/process/schedule.go
+++ b/process/schedule.go
@@ -195,6 +195,9 @@ func (s tzSchedule) Next(t time.Time) time.Time {
 }
 
 type (
+	// ContextFunc should create a child context of ctx and return a cancellation function
+	// the cancel function will be called after the process has been executed
+	// TODO(adam): Offer a CancelCauseFunc option for cancelling the context
 	ContextFunc   = func(ctx context.Context) (context.Context, context.CancelFunc, error)
 	AwaitRoleFunc = func(role string) ContextFunc
 	ScheduledFunc func(ctx context.Context, lastRunTime, runTime time.Time, runID string) error


### PR DESCRIPTION
Use Cause to return a different error if a CancelCauseFunc was called instead of just CancelFunc