### PR TITLE
Add NoApp()

### DIFF
--- a/app.go
+++ b/app.go
@@ -393,3 +393,10 @@ func handleShutdownErr(a *App, ac AppContext, err error) error {
 	}
 	return err
 }
+
+// NoApp returns a nil app.
+// It can be used when you call a function that accepts a *App, but there's no lu app in scope.
+// f(lu.NoApp()) reads more clearly than f(nil).
+func NoApp() *App {
+	return nil
+}

--- a/app_test.go
+++ b/app_test.go
@@ -370,3 +370,7 @@ func TestWaitFor(t *testing.T) {
 		})
 	}
 }
+
+func TestNoApp(t *testing.T) {
+	require.Nil(t, lu.NoApp())
+}


### PR DESCRIPTION
As per the function comments, this is a helper function to make code that uses lu more readable.

If a function may accept a `*lu.App` but not require it to be non-nil. In that case, `fn(lu.NoApp())` is clearer than `fn(nil)`. 

This emulates `context.TODO()`, in a way.