### PR TITLE
app: Terminate immediately on error

### DIFF
--- a/app.go
+++ b/app.go
@@ -165,11 +165,13 @@ func (a *App) Run() int {
 	err := a.Shutdown()
 	if err != nil {
 		// NoReturnErr: Handle, log, and exit
+		var code int
 		err = handleShutdownErr(a, ac, err)
 		if err != nil {
 			log.Error(ctx, errors.Wrap(err, "app shutdown"))
+			code = 1
 		}
-		return 1
+		return code
 	}
 
 	log.Info(ctx, "Waiting to terminate")

--- a/app.go
+++ b/app.go
@@ -159,24 +159,27 @@ func (a *App) Run() int {
 		log.Error(ctx, errors.Wrap(err, "app launch"))
 		return 1
 	}
+
 	<-a.WaitForShutdown()
-	var exit int
+
 	err := a.Shutdown()
 	if err != nil {
-		// NoReturnErr: Log
+		// NoReturnErr: Handle, log, and exit
 		err = handleShutdownErr(a, ac, err)
-		log.Error(ctx, errors.Wrap(err, "app shutdown"))
-		exit = 1
+		if err != nil {
+			log.Error(ctx, errors.Wrap(err, "app shutdown"))
+		}
+		return 1
 	}
 
-	log.Info(ctx, "Waiting to terminate", j.MKV{"exit_code": exit})
+	log.Info(ctx, "Waiting to terminate")
 
 	// Wait for termination in case we've only been told to quit
 	<-ac.TerminationContext.Done()
 
-	log.Info(ctx, "App terminated", j.MKV{"exit_code": exit})
+	log.Info(ctx, "App terminated")
 
-	return exit
+	return 0
 }
 
 // Launch will run all the startup hooks and launch all the processes.


### PR DESCRIPTION
If the app returns an error for Shutdown then we shouldn't be waiting for a termination signal to terminate.

This can happen if the application needs to terminate itself. The process that returned an error will terminate the app, but it will still get caught on the termination context because the controlling process doesn't need the app to terminate.

Returning directly on error will skip waiting for termination and exit with an error code.