### PR TITLE
gomod: Update Go version to 1.24.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/lu
 
-go 1.22.3
+go 1.24.3
 
 require (
 	github.com/go-stack/stack v1.8.1


### PR DESCRIPTION
## Changed
- Updated `go` directive in go.mod from `go 1.22.3` to `go 1.24.3`

## Rationale
- Go 1.24.3 is the latest patch release of Go 1.24
- This ensures the project can update to other libraries that declare _their_ minimum version as 1.24
- Aligns with other Luno repositories that are already using Go 1.24.x