### PR TITLE
ci: test latest Go only and bump go.mod to 1.26.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,10 +12,6 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        go: ['1.24','1']
-
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v6
@@ -23,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
+          go-version: '1'
         id: go
 
       - name: Vet

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/lu
 
-go 1.25.3
+go 1.26.0
 
 require (
 	github.com/go-stack/stack v1.8.1


### PR DESCRIPTION
Simplify the CI test matrix to only test with the latest Go (`'1'`), and bump the `go` directive in `go.mod` to `1.26.0`.

Testing multiple Go versions caused flaky failures whenever we bumped deps ahead of the oldest supported version. Since we don't commit to long-term compatibility with older Go releases, there's no value in the matrix.